### PR TITLE
Explicitly require the initializer generator

### DIFF
--- a/spec/lib/generators/wine_bouncer/initializer_generator_spec.rb
+++ b/spec/lib/generators/wine_bouncer/initializer_generator_spec.rb
@@ -1,6 +1,7 @@
 require 'generator_spec'
 require 'rails_helper'
 require 'spec_helper'
+require 'generators/wine_bouncer/initializer_generator'
 
 describe WineBouncer::Generators::InitializerGenerator, type: :generator do
   destination File.expand_path("../../tmp", __FILE__)


### PR DESCRIPTION
Hi Sunny

Re: https://github.com/stevehodgkiss/generator_spec/issues/39

The NameError was happening because the initializer constant wasn't loaded, and active support couldn't automatically load it (it would have tried to find "wine_bouncer/generators/initializer_generator" somewhere on the load path). Explicitly loading it here fixes the issue.
